### PR TITLE
Change "Base Key" to "Base ID" to match airtable API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * Please make a copy of the template Airtable Base: [https://go.mingjie.info/template](https://go.mingjie.info/template)
 * Please also grab the Airtable API Key & Base Key from the API documentations. Head [here](https://airtable.com/api) and click on the base you just created to get started.
-* Set `AIRTABLE_BASE` to your Base Key, and `AIRTABLE_KEY` to your API Key.
+* Set `AIRTABLE_BASE` to your Base ID, and `AIRTABLE_KEY` to your API Key.
 * Set `LOGGING` to `on` if you want to enable logging, `off` if otherwise.
 * Set `BOT_LOGGING` to `on` if you want to enable logging for crawlers, `off` if otherwise.
 * Set `CACHE_EXPIRATION` to the number of seconds you want the local cache to be valid.


### PR DESCRIPTION
[In airtable's API documentation](https://airtable.com/api), they refer to the key for the base as the "Base ID", so this changes how it is referred to in the README.md

![Screenshot of an Airtable API documentation for an Airtable Base, with the paragraph "The ID of this base is: ______" highlighted](https://user-images.githubusercontent.com/18013689/85931175-ab266900-b87f-11ea-8205-fcc8c01ca3e3.png)
