### PR TITLE
Implemented Command To View History By Timerange

### DIFF
--- a/app.js
+++ b/app.js
@@ -889,13 +889,8 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(command) {
-
-    console.log(`recordChanges: command: ${command}`);
-
-    const args = command.split(' ');
-    console.log(`recordChanges: args: ${args}`);
-    const [date1, date2] = args;
+async function recordChanges(date1,date2) {
+    
     console.log(`recordChanges: date1: ${date1}, date2: ${date2}`);
 
     if (!date1 || !date2) {

--- a/app.js
+++ b/app.js
@@ -399,7 +399,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         },
         record: {
             run: recordChanges,
-            arguments: [1,2],
+            arguments: [2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
             usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",

--- a/app.js
+++ b/app.js
@@ -889,10 +889,7 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(date1,date2) {
-    
-    console.log(`recordChanges: date1: ${date1}, date2: ${date2}`);
-
+async function recordChanges(date1, date2) {
     if (!date1 || !date2) {
         console.error(`recordChanges: One or both dates are undefined - date1: ${date1}, date2: ${date2}`);
         return {
@@ -901,15 +898,17 @@ async function recordChanges(date1,date2) {
         };
     }
 
-    const startDate = `${date1}T00:00:00.000Z`;
-    const endDate = `${date2}T23:59:59.999Z`;
+    const startDate = new Date(date1).toISOString();
+    const endDate = new Date(date2);
+    endDate.setUTCHours(23, 59, 59, 999);
+    const endDateString = endDate.toISOString();
 
     try {
         const res = await client.query(`
             SELECT * FROM "slughistory"
             WHERE changed_at >= $1 AND changed_at <= $2
             ORDER BY changed_at DESC;
-        `, [startDate, endDate]);
+        `, [startDate, endDateString]);
 
         if (res.rows.length > 0) {
             const blocks = res.rows.map(record => ({
@@ -929,7 +928,7 @@ async function recordChanges(date1,date2) {
                     },
                     {
                         type: 'mrkdwn',
-                        text: `*Date:* ${record.changed_at}`
+                        text: `*Date:* ${new Date(record.changed_at).toISOString()}`
                     }
                 ]
             }));

--- a/app.js
+++ b/app.js
@@ -891,6 +891,8 @@ function formatLogData(logData, clicks) {
 
 async function recordChanges(command) {
 
+    console.log(`recordChanges: command: ${command}`);
+
     const args = command.split(' ');
     console.log(`recordChanges: args: ${args}`);
     const [date1, date2] = args;

--- a/app.js
+++ b/app.js
@@ -399,7 +399,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         },
         record: {
             run: recordChanges,
-            arguments: [2,3],
+            arguments: [1,2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
             usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",

--- a/app.js
+++ b/app.js
@@ -397,13 +397,13 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
             usage: "/hack.af note [slug-name] [note-content]",
             parameters: "[slug-name]: The slug you want to add/update a note for.\n[note-content]: The content of the note."
         },
-        record: {
-            run: recordChanges,
+        audit: {
+            run: auditChanges,
             arguments: [2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
-            usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",
-            parameters: "[YYYY-MM-DD]: The start date for the record search.\n[YYYY-MM-DD]: The end date for the record search."
+            usage: "/hack.af audit [YYYY-MM-DD] [YYYY-MM-DD]",
+            parameters: "[YYYY-MM-DD]: The start date for the audit search.\n[YYYY-MM-DD]: The end date for the audit search."
         }
     }
 
@@ -889,7 +889,7 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(date1, date2) {
+async function auditChanges(date1, date2) {
     if (!date1 || !date2) {
         console.error(`recordChanges: One or both dates are undefined - date1: ${date1}, date2: ${date2}`);
         return {

--- a/app.js
+++ b/app.js
@@ -911,31 +911,38 @@ async function recordChanges(date1, date2) {
         `, [startDate, endDateString]);
 
         if (res.rows.length > 0) {
-            const blocks = res.rows.map(record => ({
-                type: 'section',
-                fields: [
-                    {
-                        type: 'mrkdwn',
-                        text: `*Slug:* ${record.slug}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Action:* ${record.action_type}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Changed By:* ${record.changed_by}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Date:* ${new Date(record.changed_at).toISOString()}`
-                    }
-                ]
-            }));
+            const blocks = res.rows.map(record => {
+                const slugText = /^https?:\/\//.test(record.slug)
+                    ? record.slug
+                    : `hack.af/${record.slug}`;
+
+                return {
+                    type: 'section',
+                    fields: [
+                        {
+                            type: 'mrkdwn',
+                            text: `*Slug:* ${slugText}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Action:* ${record.action_type}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Changed By:* ${record.changed_by}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Date:* ${new Date(record.changed_at).toISOString()}`
+                        }
+                    ]
+                };
+            });
 
             return {
                 text: `Changes from ${date1} to ${date2}:`,
-                blocks: blocks
+                blocks: blocks,
+                response_type: 'ephemeral'
             };
         } else {
             return {


### PR DESCRIPTION
as @grymmy requested and talked about on issues #83 and #79 , this implements a new command called record which works like /hack.af audit [start-date] [end-date]

/hack.af audit [YYYY-MM-DD] [YYYY-MM-DD]: (Admin only) List all changes to slugs within a given period.
Parameters: [YYYY-MM-DD]: The start date for the audit search.
[YYYY-MM-DD]: The end date for the audit search.

example output:
![image](https://github.com/hackclub/hack.af/assets/34939959/76f506c2-8c99-4b79-b68f-0eae960cdfd3)
