### PR TITLE
Implement geolocation command to retrieve user ips

### DIFF
--- a/app.js
+++ b/app.js
@@ -983,12 +983,11 @@ async function auditChanges(date1, date2, limit = 50) {
 
 async function getGeolocation(command) {
     try {
-        console.log(command.text)
-        console.log(command.channel_id)
-        console.log(command)
+        const args = command.text.split(' ');
+        const slug = args[1];
         const queryResult = await client.query(`
             SELECT "Visitor IPs" FROM "Links" WHERE slug = $1
-        `, [command.text]);
+        `, [slug]);
 
         if (queryResult.rows.length > 0) {
             const visitorIPs = queryResult.rows[0]["Visitor IPs"];

--- a/app.js
+++ b/app.js
@@ -15,6 +15,8 @@ import { LRUCache } from 'lru-cache';
 import { writeFile } from 'fs/promises';
 import { createReadStream } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 dotenv.config();
 

--- a/app.js
+++ b/app.js
@@ -889,13 +889,8 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(command) {
-
-    console.log(`recordChanges: command: ${command}`);
-
-    const args = command.split(' ');
-    console.log(`recordChanges: args: ${args}`);
-    const [date1, date2] = args;
+async function recordChanges(date1,date2) {
+    
     console.log(`recordChanges: date1: ${date1}, date2: ${date2}`);
 
     if (!date1 || !date2) {

--- a/app.js
+++ b/app.js
@@ -1009,7 +1009,7 @@ async function getGeolocation(command) {
             await insertSlugHistory(slug, 'Geolocation data retrieved', 'Used', '', command.user_id);
 
             return {
-                text: `Uploaded the geolocation data for slug ${slug}.`,
+                text: `The geolocation data for slug ${slug} has been sent to your direct messages.`,
                 response_type: 'ephemeral'
             };
         } else {

--- a/app.js
+++ b/app.js
@@ -439,6 +439,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         metrics.increment(`botcommands.${args[0]}.attempt`, 1);
 
         let result;
+        console.log("Command entry:", commandEntry);
         if (commandEntry.run === getGeolocation) {
             result = await getGeolocation(command);
         } else {

--- a/app.js
+++ b/app.js
@@ -399,7 +399,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         },
         record: {
             run: recordChanges,
-            arguments: [1,2],
+            arguments: [2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
             usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",

--- a/app.js
+++ b/app.js
@@ -889,10 +889,7 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(date1,date2) {
-    
-    console.log(`recordChanges: date1: ${date1}, date2: ${date2}`);
-
+async function recordChanges(date1, date2) {
     if (!date1 || !date2) {
         console.error(`recordChanges: One or both dates are undefined - date1: ${date1}, date2: ${date2}`);
         return {
@@ -901,15 +898,17 @@ async function recordChanges(date1,date2) {
         };
     }
 
-    const startDate = `${date1}T00:00:00.000Z`;
-    const endDate = `${date2}T23:59:59.999Z`;
+    const startDate = new Date(date1).toISOString();
+    const endDate = new Date(date2);
+    endDate.setUTCHours(23, 59, 59, 999);
+    const endDateString = endDate.toISOString();
 
     try {
         const res = await client.query(`
             SELECT * FROM "slughistory"
             WHERE changed_at >= $1 AND changed_at <= $2
             ORDER BY changed_at DESC;
-        `, [startDate, endDate]);
+        `, [startDate, endDateString]);
 
         if (res.rows.length > 0) {
             const blocks = res.rows.map(record => ({
@@ -929,7 +928,7 @@ async function recordChanges(date1,date2) {
                     },
                     {
                         type: 'mrkdwn',
-                        text: `*Date:* ${record.changed_at}`
+                        text: `*Date:* ${new Date(record.changed_at).toISOString()}`
                     }
                 ]
             }));

--- a/app.js
+++ b/app.js
@@ -891,6 +891,8 @@ function formatLogData(logData, clicks) {
 
 async function recordChanges(command) {
 
+    console.log(`recordChanges: command: ${command}`);
+
     const args = command.split(' ');
     console.log(`recordChanges: args: ${args}`);
     const [date1, date2] = args;

--- a/app.js
+++ b/app.js
@@ -399,7 +399,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         },
         record: {
             run: recordChanges,
-            arguments: [2,3],
+            arguments: [1,2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
             usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",

--- a/app.js
+++ b/app.js
@@ -397,13 +397,13 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
             usage: "/hack.af note [slug-name] [note-content]",
             parameters: "[slug-name]: The slug you want to add/update a note for.\n[note-content]: The content of the note."
         },
-        record: {
-            run: recordChanges,
+        audit: {
+            run: auditChanges,
             arguments: [2],
             staffRequired: true,
             helpEntry: "List all changes to slugs within a given time period.",
-            usage: "/hack.af record [YYYY-MM-DD] [YYYY-MM-DD]",
-            parameters: "[YYYY-MM-DD]: The start date for the record search.\n[YYYY-MM-DD]: The end date for the record search."
+            usage: "/hack.af audit [YYYY-MM-DD] [YYYY-MM-DD]",
+            parameters: "[YYYY-MM-DD]: The start date for the audit search.\n[YYYY-MM-DD]: The end date for the audit search."
         }
     }
 
@@ -889,7 +889,7 @@ function formatLogData(logData, clicks) {
     `;
 }
 
-async function recordChanges(date1, date2) {
+async function auditChanges(date1, date2) {
     if (!date1 || !date2) {
         console.error(`recordChanges: One or both dates are undefined - date1: ${date1}, date2: ${date2}`);
         return {

--- a/app.js
+++ b/app.js
@@ -442,7 +442,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         if (commandEntry.run === getGeolocation) {
             result = await getGeolocation(command);
         } else {
-            const result = acceptsVariableArguments ?
+            result = acceptsVariableArguments ?
                 await commandEntry.run(...args.slice(1)) :
                 await commandEntry.run(...args.slice(1, commandEntry.arguments[0] + 1));
         }

--- a/app.js
+++ b/app.js
@@ -911,31 +911,38 @@ async function recordChanges(date1, date2) {
         `, [startDate, endDateString]);
 
         if (res.rows.length > 0) {
-            const blocks = res.rows.map(record => ({
-                type: 'section',
-                fields: [
-                    {
-                        type: 'mrkdwn',
-                        text: `*Slug:* ${record.slug}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Action:* ${record.action_type}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Changed By:* ${record.changed_by}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Date:* ${new Date(record.changed_at).toISOString()}`
-                    }
-                ]
-            }));
+            const blocks = res.rows.map(record => {
+                const slugText = /^https?:\/\//.test(record.slug)
+                    ? record.slug
+                    : `hack.af/${record.slug}`;
+
+                return {
+                    type: 'section',
+                    fields: [
+                        {
+                            type: 'mrkdwn',
+                            text: `*Slug:* ${slugText}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Action:* ${record.action_type}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Changed By:* ${record.changed_by}`
+                        },
+                        {
+                            type: 'mrkdwn',
+                            text: `*Date:* ${new Date(record.changed_at).toISOString()}`
+                        }
+                    ]
+                };
+            });
 
             return {
                 text: `Changes from ${date1} to ${date2}:`,
-                blocks: blocks
+                blocks: blocks,
+                response_type: 'ephemeral'
             };
         } else {
             return {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "chai": "^4.3.10",
     "dotenv": "^8.6.0",
     "express": "^4.17.1",
+    "fs": "^0.0.1-security",
     "isbot": "^2.4.0",
     "lru-cache": "^10.0.0",
     "mocha": "^10.2.0",
     "node-statsd": "^0.1.1",
+    "path": "^0.12.7",
     "pg": "^8.11.0",
     "response-time": "^2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node-statsd": "^0.1.1",
     "path": "^0.12.7",
     "pg": "^8.11.0",
-    "response-time": "^2.3.2"
+    "response-time": "^2.3.2",
+    "url": "^0.11.3"
   },
   "scripts": {
     "start": "node app.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,7 +135,7 @@
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/node@*", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@18.16.0":
+"@types/node@*", "@types/node@18.16.0", "@types/node@>=12", "@types/node@>=12.0.0":
   version "18.16.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz"
   integrity sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==
@@ -394,7 +394,7 @@ check-error@^1.0.3:
   dependencies:
     get-func-name "^2.0.2"
 
-chokidar@^3.5.2, chokidar@3.5.3:
+chokidar@3.5.3, chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -464,13 +464,6 @@ cookie@0.5.0:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-debug@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -484,6 +477,13 @@ debug@4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -510,15 +510,15 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@~1.1.0:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
-  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
-
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+depd@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -785,6 +785,16 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -952,6 +962,11 @@ inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"
@@ -1262,19 +1277,19 @@ mime@1.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-minimatch@^3.0.4, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz"
   integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimatch@^3.0.4, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 mocha@^10.2.0:
   version "10.2.0"
@@ -1303,11 +1318,6 @@ mocha@^10.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -1318,7 +1328,7 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1477,15 +1487,23 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
 path-to-regexp@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz"
   integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
 
 pathval@^1.1.1:
   version "1.1.1"
@@ -1528,7 +1546,7 @@ pg-types@^2.1.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.11.0, pg@>=8.0:
+pg@^8.11.0:
   version "8.11.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz"
   integrity sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==
@@ -1584,6 +1602,11 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+process@^0.11.1:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 promise.allsettled@^1.0.2:
   version "1.0.6"
   resolved "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.6.tgz"
@@ -1628,7 +1651,7 @@ range-parser@~1.2.1:
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@^2.3.3, raw-body@2.5.1:
+raw-body@2.5.1, raw-body@^2.3.3:
   version "2.5.1"
   resolved "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz"
   integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
@@ -1672,7 +1695,7 @@ retry@^0.13.1:
   resolved "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1835,6 +1858,13 @@ strip-json-comments@3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+supports-color@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -1846,13 +1876,6 @@ supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1917,10 +1940,17 @@ undefsafe@^2.0.5:
   resolved "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-unpipe@~1.0.0, unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -1994,7 +2024,7 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^20.2.2, yargs-parser@20.2.4:
+yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1632,10 +1632,22 @@ pstree.remy@^1.1.8:
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
   dependencies:
     side-channel "^1.0.4"
 
@@ -1944,6 +1956,14 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+url@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.3.tgz#6f495f4b935de40ce4a0a52faee8954244f3d3ad"
+  integrity sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==
+  dependencies:
+    punycode "^1.4.1"
+    qs "^6.11.2"
 
 util@^0.10.3:
   version "0.10.4"


### PR DESCRIPTION
As requested on #80, I have added a new command called geolocation to retrieve the ip's of whoever had clicked the link on a hack.af/<custom slug>

command:
![image](https://github.com/hackclub/hack.af/assets/34939959/94fe7d0e-de1b-41aa-b157-ccd93b50674c)

due to the limit of Slack upload where you can't make files only seen by a user who ran, the logs are sent in the DM of the user, and the logs are converted into.csv which can be downloaded and easy to use if needed rather than current array string

also, it's added to Slug history so it can be audited and see in the future who used the command from the slug