### PR TITLE
Show Ran Commands

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
     await ack();
 
     const args = command.text.split(' ');
+    const originalCommand = `/${command.command} ${command.text}`;
     const isStaff = await isStaffMember(command.user_id);
     async function changeSlug(slug, newDestination) {
         newDestination = newDestination.replace(/^[\*_`]+|[\*_`]+$/g, '');
@@ -438,7 +439,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
 
     if (commandEntry.staffRequired && !isStaff)
         return await respond({
-            text: 'Sorry, only staff can use this command',
+            text: 'Sorry, only staff can use this command. Command run: \`${originalCommand}\`',
             response_type: 'ephemeral'
         });
 
@@ -446,7 +447,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
 
     if (!acceptsVariableArguments && !commandEntry.arguments.includes(args.length - 1))
         return await respond({
-            text: `The command accepts ${commandEntry.arguments.join(', ')} arguments, but you supplied ${args.length - 1}. Please check your formatting.`,
+            text: `The command accepts ${commandEntry.arguments.join(', ')} arguments, but you supplied ${args.length - 1}. Please check your formatting. Command run: \`${originalCommand}\``,
             response_type: 'ephemeral'
         });
 
@@ -464,6 +465,15 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
                 await commandEntry.run(...args.slice(1, commandEntry.arguments[0] + 1));
         }
 
+        result.blocks.push({
+            type: 'context',
+            elements: [
+                {
+                    type: 'mrkdwn',
+                    text: `Command run: \`${originalCommand}\``
+                }
+            ]
+        });
         await respondEphemeral(respond, result);
 
         metrics.increment(`botcommands.${args[0]}.success`, 1);
@@ -473,7 +483,7 @@ SlackApp.command("/hack.af", async ({ command, ack, respond }) => {
         metrics.increment(`botcommands.${args[0]}.error`, 1);
 
         await respond({
-            text: `There was an error processing your request: ${error.message}`,
+            text: `There was an error processing your request: ${error.message}. Command run: \`${originalCommand}\``,
             response_type: 'ephemeral'
         });
         console.error(error);


### PR DESCRIPTION
As requested by @maxwofford I have implemented a command using trace v1 which fixes #96

![image](https://github.com/hackclub/hack.af/assets/34939959/237e737e-f66b-48eb-ae11-aa2c935d0571)
![image](https://github.com/hackclub/hack.af/assets/34939959/f07766fa-f2f9-4292-8227-99f25e865ae5)


currently, I have implemented logs as comments under the ran command as shown in the image above ^^

The example shown on the bot uses a different mechanic and it will take extra rework so proposing this alternative, Lmk if this this is all right or rewrite the current system to use the same mechanic.