### PR TITLE
/gh/repo

### DIFF
--- a/app.js
+++ b/app.js
@@ -522,6 +522,10 @@ app.get("/gib/:org", (req, res) => {
     res.redirect(302, "https://hcb.hackclub.com/donations/start/" + req.params.org);
 });
 
+app.get("/gh/:repo", (req, res) => {
+    res.redirect(302, "https://github.com/hackclub/" + req.params.repo);
+});
+
 app.get("/*", (req, res) => {
     let slug = decodeURIComponent(req.path.substring(1));
     const query = req.query;


### PR DESCRIPTION
redirects /gh/<repo> to github.com/hackclub/<repo>

a useful shorthand i might say