### PR TITLE
feat: add /f/:form route

### DIFF
--- a/app.js
+++ b/app.js
@@ -574,6 +574,10 @@ app.get(/^\/odr!(.+)$/, (req, res) => {
     res.redirect(302, "https://fulfillment.hackclub.com/odr!" + req.params[0]);
 })
 
+app.get("/f/:form", (req, res) => {
+    res.redirect(302, "https://forms.hackclub.com/" + req.params.form);
+});
+
 app.get(["/*path", "/"], (req, res) => {
     let slug = decodeURIComponent(req.path.substring(1));
     const query = req.query;


### PR DESCRIPTION
typing out forms.hackclub.com/whatever a ton is getting annoying, hack.af/f/whatever is just enough shorter that it's a bit easier to type.

this PR adds `hack.af/f/:form` which just redirects to `forms.hackclub.com/:form`