### PR TITLE
Update club links and add HCB organization link

### DIFF
--- a/app.js
+++ b/app.js
@@ -545,6 +545,10 @@ app.get("/gib/:org", (req, res) => {
     res.redirect(302, "https://hcb.hackclub.com/donations/start/" + req.params.org);
 });
 
+app.get("/hcb/:org", (req, res) => {
+    res.redirect(302, "https://hcb.hackclub.com/" + req.params.org);
+});
+
 app.get("/gh/:repo", (req, res) => {
     res.redirect(302, "https://github.com/hackclub/" + req.params.repo);
 });

--- a/app.js
+++ b/app.js
@@ -554,16 +554,7 @@ app.get("/gh/:repo", (req, res) => {
 });
 
 app.get("/join/:code", (req, res) => {
-    res.redirect(302, "https://leaders.hackclub.com/join/" + req.params.code);
-});
-
-
-app.get("/club/:name", (req, res) => {
-    res.redirect(302, "https://leaders.hackclub.com/redirect/" + req.params.name);
-});
-
-app.get("/confirm/:code", (req, res) => {
-    res.redirect(302, "https://leaders.hackclub.com/confirm/" + req.params.code);
+    res.redirect(302, "https://clubs.hackclub.com/auth/member?join=" + req.params.code);
 });
 
 app.get(/^\/pkg!(.+)$/, (req, res) => {


### PR DESCRIPTION
The commits for this PR have all been made from GitHub Mobile. :sob:

- Remove old links to leaders.hackclub.com
- Add join code for clubs.hackclub.com
- Add a redirect to any HCB org with `hack.af/hcb/...`